### PR TITLE
Topic/switch python3

### DIFF
--- a/ruby-2.7-tfenv-python3.dockerfile
+++ b/ruby-2.7-tfenv-python3.dockerfile
@@ -1,0 +1,15 @@
+FROM circleci/ruby:2.7
+LABEL maintainer "Tomoya KABE<kabe@elastic-infra.com>"
+
+RUN sudo apt-get update && sudo apt-get install -y \
+    cmake \
+    libpcap-dev \
+    python-pip \
+    python-dev \
+    vim \
+ && sudo apt-get clean \
+ && sudo rm -rf /var/lib/apt/lists/*
+RUN sudo pip install awscli
+RUN sudo gem install terraform_landscape
+RUN git clone https://github.com/tfutils/tfenv.git ~/.tfenv
+RUN sudo ln -s ~/.tfenv/bin/* /usr/local/bin

--- a/ruby-2.7-tfenv-python3.dockerfile
+++ b/ruby-2.7-tfenv-python3.dockerfile
@@ -1,15 +1,16 @@
 FROM circleci/ruby:2.7
 LABEL maintainer "Tomoya KABE<kabe@elastic-infra.com>"
 
+RUN sudo ln -sf /usr/bin/python3 /usr/bin/python
 RUN sudo apt-get update && sudo apt-get install -y \
     cmake \
     libpcap-dev \
-    python-pip \
-    python-dev \
+    python3-pip \
+    python3-dev \
     vim \
  && sudo apt-get clean \
  && sudo rm -rf /var/lib/apt/lists/*
-RUN sudo pip install awscli
+RUN sudo pip3 install awscli
 RUN sudo gem install terraform_landscape
 RUN git clone https://github.com/tfutils/tfenv.git ~/.tfenv
 RUN sudo ln -s ~/.tfenv/bin/* /usr/local/bin


### PR DESCRIPTION
https://github.com/elastic-infra/ei-terraform/pull/1428
External data sourceを使うにあたって、このPRで使っている `terraform_external_data` がPython3のみサポートしています。
CircleCIで利用しているDocker imageのpythonが2系のためCIがコケるので、その修正PRになります。

Docker Hubへの上げ方とかどうするんだろう 🤔 